### PR TITLE
Docs improvements

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -28,7 +28,7 @@ webpack:
 
 Now you can use the `{webpack}` macro in your templates. It automatically expands the provided asset name to the full path as configured:
 
-```html
+```latte
 <script src="{webpack app.js}"></script>
 ```
 

--- a/.docs/README.md
+++ b/.docs/README.md
@@ -15,14 +15,14 @@ composer require contributte/webpack
 
 Register the extension in your config file, and configure it. The two `build` options are mandatory:
 
-```yaml
+```neon
 extensions:
-    webpack: Contributte\Webpack\DI\WebpackExtension(%debugMode%, %consoleMode%)
+	webpack: Contributte\Webpack\DI\WebpackExtension(%debugMode%, %consoleMode%)
 
 webpack:
-    build:
-        directory: %wwwDir%/dist
-        publicPath: dist/
+	build:
+		directory: %wwwDir%/dist
+		publicPath: dist/
 ```
 
 
@@ -39,34 +39,34 @@ You might want to use the Webpack's [dev server](https://www.npmjs.com/package/w
 
 This package effectively solves this problem: it automatically serves assets from the dev server if available (i.e. it responds within a specified timeout), and falls back to the build directory otherwise. All you have to do is configure the dev server URL. The dev server is enabled automatically in debug mode; you can override this setting via `enabled` option:
 
-```yaml
+```neon
 webpack:
-    devServer:
-        enabled: %debugMode% # default
-        url: http://localhost:3000
-        timeout: 0.1 # (seconds) default
+	devServer:
+		enabled: %debugMode% # default
+		url: http://localhost:3000
+		timeout: 0.1 # (seconds) default
 ```
 
 #### Ignored assets
 
 You can also configure a set of asset names that should be ignored (i.e. resolved to an empty data URI) if the dev-server is available. This can be helpful e.g. if you use [`style-loader`](https://www.npmjs.com/package/style-loader) in development which does not emit any CSS files.
 
-```yaml
+```neon
 webpack:
-    devServer:
-        ignoredAssets:
-            - main.css
+	devServer:
+		ignoredAssets:
+			- main.css
 ```
 
 #### Public URL (e.g. Docker usage)
 
 Dev-server might have different URLs for different access points. For example, when running in Docker Compose setup, the Nette application accesses it via the internal Docker network, while you access it in the browser via the exposed port. For this, you can set up a different `publicUrl`.   
 
-```yaml
+```neon
 webpack:
-    devServer:
-        url: http://webpack-dev-server:3000 # URL over internal Docker network
-        publicUrl: http://localhost:3030 # exposed port from the dev-server container
+	devServer:
+		url: http://webpack-dev-server:3000 # URL over internal Docker network
+		publicUrl: http://localhost:3030 # exposed port from the dev-server container
 ```
 
 
@@ -76,10 +76,10 @@ You might want to include the Webpack's asset hash in its file name for assets c
 
 This package comes to the rescue. You can employ the [`webpack-manifest-plugin`](https://www.npmjs.com/package/webpack-manifest-plugin) or some similar plugin (see below) to produce a manifest file, and then configure the adapter to use it:
 
-```yaml
+```neon
 webpack:
-    manifest:
-        name: manifest.json
+	manifest:
+		name: manifest.json
 ```
 
 This way, you can keep using the original asset names, and they get expanded automatically following the resolutions from the manifest file.
@@ -91,11 +91,11 @@ This package automatically optimizes this in production environment by loading t
 
 By default, the manifest loader supports the aforementioned `webpack-manifest-plugin`. If you use a different plugin that produces the manifest in a different format, you can implement and configure a mapper for it. This package comes bundled with a mapper for the [`assets-webpack-plugin`](https://www.npmjs.com/package/assets-webpack-plugin):
 
-```yaml
+```neon
 webpack:
-    manifest:
-        name: manifest.json
-        mapper: Contributte\Webpack\Manifest\Mapper\AssetsWebpackPluginMapper
+	manifest:
+		name: manifest.json
+		mapper: Contributte\Webpack\Manifest\Mapper\AssetsWebpackPluginMapper
 ```
 
 You can also implement your own mapper, simply extend `Contributte\Webpack\Manifest\ManifestMapper` and implement its `map()` method. It takes the parsed JSON content of the manifest file and is expected to return a flat array mapping asset names to file names.


### PR DESCRIPTION
Polished docs
- use 4 spaces in CSS, in JS, in HTML and in Latte
- use tab in NEON and in PHP
- neon highlighting syntax
- normalized filename of Readmes
- typos